### PR TITLE
Add sample ansible role for installation

### DIFF
--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -1,0 +1,40 @@
+# Role `jidlobot`
+
+Install and configure [jidlobot](https://github.com/helb/jidlobot) on
+debian-like system.
+
+The role currently support only *mattermost* module.
+
+
+## Variables
+
+| Variable          | Required | Default      | Description |
+| ----------------- | -------- | ------------ | ----------- |
+| jidlobot_urls     | yes      |              | List of *menicka* URLs of desired restaurants (value of `URLS` config parameter) |
+|                   |          |              |  |
+| jidlobot_mattermost_webhook | yes |         | URL for Mattermost webhook (`MATTERMOST_WEBHOOK` parameter) |
+| jidlobot_mattermost_channel | yes |         | Used Mattermost channel (`MATTERMOST_CHANNEL` parameter) |
+| jidlobot_mattermost_username | yes |        | Used bot's username (`MATTERMOST_USERNAME` parameter) |
+|                   |          |              |  |
+| jidlobot_install_path | no   | /opt/jidlobot | Directory where jidlobot would be installed |
+|                   |          |              |  |
+| jidlobot_admin_mail | no     |              | `MAILTO` recipients in cron job |
+| jidlobot_cron     | no       |              | Dictionary with following parameters |
+| .hour             | no       | *            | `hour` parameter for cron job |
+| .minute           | no       | *            | `minute` parameter for cron job |
+| .day              | no       | *            | `day` parameter for cron job |
+| .month            | no       | *            | `month` parameter for cron job |
+| .weekday          | no       | *            | `weekday` parameter for cron job |
+
+Default `jidlobot_cron` variable is set to:
+```
+jidlobot_cron:
+  hour: '10'
+  minute: '58'
+  weekday: '1-5'
+```
+
+If any of the parameters is not defined, it is omitted from module parameters.
+See
+[cron module documentation](https://docs.ansible.com/ansible/latest/cron_module.html#options)
+for details.

--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Ansible vars
+#
+# Default variables for jidlobot role
+
+jidlobot_admin_mail: ''
+
+jidlobot_cron:
+  hour: '10'
+  minute: '58'
+  weekday: '1-5'
+
+jidlobot_repo_url: 'https://github.com/helb/jidlobot.git'
+jidlobot_install_path: '/opt/jidlobot'
+
+jidlobot_requirements:
+  - git
+  - python3
+  - virtualenv
+  - libyaml-dev
+
+...

--- a/ansible-role/tasks/main.yml
+++ b/ansible-role/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+# Ansible role
+#
+# Install and configure jidlobot
+
+- name: Create jidlobot user
+  user:
+    name: 'jidlobot'
+    group: 'nogroup'
+    shell: '/bin/false'
+    home: '/var/lib/jidlobot'
+
+- name: Install apt requirements
+  apt:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ jidlobot_requirements }}'
+
+- name: Clone jidlobot repo
+  git:
+    repo: '{{ jidlobot_repo_url }}'
+    dest: '{{ jidlobot_install_path }}'
+
+- name: Create virtualenv
+  pip:
+    virtualenv: '{{ jidlobot_install_path }}/.venv'
+    virtualenv_python: 'python3'
+    requirements: '{{ jidlobot_install_path }}/requirements.txt'
+
+- name: Configure jidlobot
+  template:
+    src: 'jidlobot.conf.j2'
+    dest: '{{ jidlobot_install_path }}/jidlobot.conf'
+    owner: 'jidlobot'
+    group: 'nogroup'
+    mode: '0600'
+
+- name: Install cron script
+  template:
+    src: 'jidlobot-cron.sh.j2'
+    dest: '/opt/jidlobot-cron.sh'
+    mode: '0755'
+
+- block:
+  - name: Cron MAILTO variable
+    cron:
+      env: yes
+      name: 'MAILTO'
+      value: '{{ jidlobot_admin_mail }}'
+      user: 'root'
+      cron_file: 'jidlobot'
+
+  - name: Configure cron
+    cron:
+      name: 'run jidlobot'
+      hour: '{{ jidlobot_cron.hour|default(omit) }}'
+      minute: '{{ jidlobot_cron.minute|default(omit) }}'
+      day: '{{ jidlobot_cron.day|default(omit) }}'
+      month: '{{ jidlobot_cron.month|default(omit) }}'
+      weekday: '{{ jidlobot_cron.weekday|default(omit) }}'
+      user: jidlobot
+      job: '/opt/jidlobot-cron.sh'
+      cron_file: 'jidlobot'
+
+  tags:
+    - cron
+
+...

--- a/ansible-role/templates/jidlobot-cron.sh.j2
+++ b/ansible-role/templates/jidlobot-cron.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd '{{ jidlobot_install_path }}'
+source .venv/bin/activate
+python jidlobot.py

--- a/ansible-role/templates/jidlobot.conf.j2
+++ b/ansible-role/templates/jidlobot.conf.j2
@@ -1,0 +1,14 @@
+## jidlobot.conf
+
+HTTP_TIMEOUT: 5
+URLS:
+{% for url in jidlobot_urls %}
+  - {{ url }}
+{% endfor %}
+
+BACKENDS:
+  - mattermost
+
+MATTERMOST_WEBHOOK: {{ jidlobot_mattermost_webhook }}
+MATTERMOST_CHANNEL: {{ jidlobot_mattermost_channel }}
+MATTERMOST_USERNAME: {{ jidlobot_mattermost_username }}


### PR DESCRIPTION
This ansible role handles installation steps in your main `README.md`.

It is used on *Rapsbian* and should work well also on *Debian* and it's derivatives