### PR TITLE
Ansible role extension

### DIFF
--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -12,10 +12,6 @@ The role currently support only *mattermost* module.
 | ----------------- | -------- | ------------ | ----------- |
 | jidlobot_urls     | yes      |              | List of *menicka* URLs of desired restaurants (value of `URLS` config parameter) |
 |                   |          |              |  |
-| jidlobot_mattermost_webhook | yes |         | URL for Mattermost webhook (`MATTERMOST_WEBHOOK` parameter) |
-| jidlobot_mattermost_channel | yes |         | Used Mattermost channel (`MATTERMOST_CHANNEL` parameter) |
-| jidlobot_mattermost_username | yes |        | Used bot's username (`MATTERMOST_USERNAME` parameter) |
-|                   |          |              |  |
 | jidlobot_install_path | no   | /opt/jidlobot | Directory where jidlobot would be installed |
 |                   |          |              |  |
 | jidlobot_admin_mail | no     |              | `MAILTO` recipients in cron job |
@@ -25,6 +21,12 @@ The role currently support only *mattermost* module.
 | .day              | no       | *            | `day` parameter for cron job |
 | .month            | no       | *            | `month` parameter for cron job |
 | .weekday          | no       | *            | `weekday` parameter for cron job |
+|                   |          |              |  |
+| jidlobot_backend  | yes      |              | Definition of jidlobot backends (see *jidlobot documentation* for details); dictionary with following parameters |
+| .console          | no       |              | Definition of console backend |
+| .mail             | no       |              | Definition of mail backend (parameters are `from`, `to`, `server`, `port`, `user`, `pw` and `starttls`) |
+| .mattermost       | no       |              | Definition of Mattermost backend (parameters are `webhook`, `channel` and `username`) |
+| .hipchat          | no       |              | Definition of Hipchat backend (parameters are `url`, `room`, `token` and `color`) |
 
 Default `jidlobot_cron` variable is set to:
 ```

--- a/ansible-role/README.md
+++ b/ansible-role/README.md
@@ -40,3 +40,53 @@ If any of the parameters is not defined, it is omitted from module parameters.
 See
 [cron module documentation](https://docs.ansible.com/ansible/latest/cron_module.html#options)
 for details.
+
+
+## Examples
+
+Simple installation with `console` backend (for testing):
+
+```yaml
+jidlobot_admin_mail: 'admin@example.cz'
+jidlobot_backend:
+  console:
+
+jidlobot_urls:
+  - https://www.menicka.cz/...
+```
+
+Send daily menus in `Mattermost` message:
+
+```yaml
+jidlobot_admin_mail: 'admin@example.cz'
+jidlobot_backend:
+  mattermost:
+    channel: 'lunch'
+    username: 'jidlobot'
+    webhook: 'https://mattermost.example.cz/hooks/s3cr3tUR1'
+
+jidlobot_urls:
+  - https://www.menicka.cz/...
+```
+
+
+Send Wednesday menus on 11:30 to e-mail recipients:
+
+```yaml
+jidlobot_admin_mail: 'admin@example.cz'
+jidlobot_backend:
+  mail:
+    from: 'jidlobot@example.cz'
+    to:
+      - admin@example.cz
+      - hungry@hippo.org
+      - foo@bar.xyz
+
+jidlobot_cron:
+  hour: '11'
+  minute: '30'
+  weekday: '3'
+
+jidlobot_urls:
+  - https://www.menicka.cz/...
+```

--- a/ansible-role/defaults/main.yml
+++ b/ansible-role/defaults/main.yml
@@ -16,6 +16,7 @@ jidlobot_install_path: '/opt/jidlobot'
 jidlobot_requirements:
   - git
   - python3
+  - python3-dev
   - virtualenv
   - libyaml-dev
 

--- a/ansible-role/templates/jidlobot.yml.j2
+++ b/ansible-role/templates/jidlobot.yml.j2
@@ -7,8 +7,43 @@ URLS:
 {% endfor %}
 
 BACKENDS:
+{% if jidlobot_backend.console is defined %}
+  - console
+{% endif %}
+{% if jidlobot_backend.mail is defined %}
+  - mail
+{% endif %}
+{% if jidlobot_backend.mattermost is defined %}
   - mattermost
+{% endif %}
+{% if jidlobot_backend.hipchat is defined %}
+  - hipchat
+{% endif %}
 
-MATTERMOST_WEBHOOK: {{ jidlobot_mattermost_webhook }}
-MATTERMOST_CHANNEL: {{ jidlobot_mattermost_channel }}
-MATTERMOST_USERNAME: {{ jidlobot_mattermost_username }}
+{% if jidlobot_backend.mail is defined %}
+MAIL_FROM: {{ jidlobot_backend.mail.from }}
+MAIL_TO:
+{%   for address in jidlobot_backend.mail.to %}
+  - {{ address }}
+{%   endfor %}
+MAIL_SERVER: {{ jidlobot_backend.mail.server|default('localhost') }}
+MAIL_PORT: {{ jidlobot_backend.mail.port|default(25) }}
+{%   if jidlobot_backend.mail.pw is defined %}
+MAIL_USER: {{ jidlobot_backend.mail.user|default(jidlobot_backend.mail.from) }}
+MAIL_PW: {{ jidlobot_backend.mail.pw }}
+{%   endif %}
+MAIL_STARTTLS: {{ jidlobot_backend.mail.starttls|default(True) }}
+{% endif %}
+
+{% if jidlobot_backend.mattermost is defined %}
+MATTERMOST_WEBHOOK: {{ jidlobot_backend.mattermost.webhook }}
+MATTERMOST_CHANNEL: {{ jidlobot_backend.mattermost.channel }}
+MATTERMOST_USERNAME: {{ jidlobot_backend.mattermost.username }}
+{% endif %}
+
+{% if jidlobot_backend.hipchat is defined %}
+HIPCHAT_URL: {{ jidlobot_backend.hipchat.url }}
+HIPCHAT_ROOM: {{ jidlobot_backend.hipchat.room }}
+HIPCHAT_TOKEN: {{ jidlobot_backend.hipchat.token }}
+HIPCHAT_COLOR: {{ jidlobot_backend.hipchat.color|default('yellow') }}
+{% endif %}


### PR DESCRIPTION
Add possibility to configure any of *jidlobot* backends

Also supports `mail` backend config presented in #4 